### PR TITLE
Return correct paths in files saves

### DIFF
--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerDelegate.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerDelegate.kt
@@ -69,7 +69,10 @@ class FilePickerDelegate(
         dispatchEventStatus(true)
         return try {
             val newUri = FileUtils.writeBytesData(context = activity, uri, bytes) ?: uri
-            finishWithSuccess(newUri.path)
+            // Get the actual file path from the URI instead of just using uri.path
+            // which might return a path in the Downloads folder regardless of where the file was saved
+            val actualPath = FileUtils.getFullPathFromTreeUri(newUri, activity) ?: newUri.path
+            finishWithSuccess(actualPath)
             true
         } catch (e: IOException) {
             Log.e(TAG, "Error while saving file", e)

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -555,6 +555,31 @@ object FileUtils {
             return null
         }
 
+        // For content URIs, try to get the actual file path
+        if (treeUri.scheme == "content") {
+            try {
+                // Try to get the display name and parent directory
+                val fileName = getFileName(treeUri, con)
+                if (fileName != null) {
+                    // Try to get the actual path from the URI
+                    val cursor = con.contentResolver.query(treeUri, null, null, null, null)
+                    cursor?.use {
+                        if (it.moveToFirst()) {
+                            val columnIndex = it.getColumnIndex("_data")
+                            if (columnIndex != -1) {
+                                val filePath = it.getString(columnIndex)
+                                if (filePath != null) {
+                                    return filePath
+                                }
+                            }
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error getting file path from URI", e)
+            }
+        }
+
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
             if (isDownloadsDocument(treeUri)) {
                 val docId = DocumentsContract.getDocumentId(treeUri)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes file path retrieval in `FilePickerDelegate.kt` by using `FileUtils.getFullPathFromTreeUri()` to handle content URIs correctly.
> 
>   - **Behavior**:
>     - In `FilePickerDelegate.kt`, `saveFile()` now uses `FileUtils.getFullPathFromTreeUri()` to get the correct file path from a URI, instead of using `uri.path`.
>     - Handles content URIs to ensure the actual file path is returned, not just a path in the Downloads folder.
>   - **FileUtils**:
>     - Adds logic in `getFullPathFromTreeUri()` to handle content URIs by querying the content resolver for the actual file path.
>     - Logs errors if file path retrieval fails in `getFullPathFromTreeUri()`.
>   - **Misc**:
>     - Minor logging changes in `FileUtils.kt` to handle exceptions during file path retrieval.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dashwave-test%2Fflutter_file_picker&utm_source=github&utm_medium=referral)<sup> for 9be7268ba7f76f8cbf9f549588ae16103bcbae5b. You can [customize](https://app.ellipsis.dev/dashwave-test/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->