### PR TITLE
Add cancelUploadOnWindowBlur parameter to prevent upload cancellation

### DIFF
--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -82,6 +82,11 @@ abstract class FilePicker extends PlatformInterface {
   /// [readSequential] can be optionally set on web to keep the import file order during import.
   /// Not supported on macOS.
   ///
+  /// [cancelUploadOnWindowBlur] can be optionally set on web to control whether the file upload
+  /// should be cancelled when the window loses focus. This is useful when extensions (particularly
+  /// for Chrome Enterprise) scan selected files with exfiltration filters, which can cause the window
+  /// to lose focus. Defaults to `true`.
+  ///
   /// The result is wrapped in a [FilePickerResult] which contains helper getters
   /// with useful information regarding the picked [List<PlatformFile>].
   ///
@@ -105,6 +110,7 @@ abstract class FilePicker extends PlatformInterface {
     bool withReadStream = false,
     bool lockParentWindow = false,
     bool readSequential = false,
+    bool cancelUploadOnWindowBlur = true,
   }) async =>
       throw UnimplementedError('pickFiles() has not been implemented.');
 


### PR DESCRIPTION
This change addresses an issue where Chrome Enterprise extensions that scan files with exfiltration filters can cause the file upload to be cancelled when the window loses focus. A new configuration parameter allows users to disable this behavior when needed.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `cancelUploadOnWindowBlur` parameter to `pickFiles()` in `file_picker.dart` to control file upload cancellation on window blur for web.
> 
>   - **Behavior**:
>     - Adds `cancelUploadOnWindowBlur` parameter to `pickFiles()` in `file_picker.dart`.
>     - Controls file upload cancellation on window blur, defaulting to `true`.
>     - Useful for Chrome Enterprise extensions that scan files, causing window focus loss.
>   - **Misc**:
>     - Updates documentation for `pickFiles()` to include `cancelUploadOnWindowBlur` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dashwave-test%2Fflutter_file_picker&utm_source=github&utm_medium=referral)<sup> for 77e0a5b28438a86d9321f5f2836751665d7e6980. You can [customize](https://app.ellipsis.dev/dashwave-test/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->